### PR TITLE
fix: initialize submodules after worktree creation

### DIFF
--- a/wt
+++ b/wt
@@ -326,6 +326,13 @@ copy_files_to_worktree() {
   done <<< "$files"
 }
 
+init_submodules() {
+  local root="$1"
+  local path="$2"
+  [ -f "$root/.gitmodules" ] || return 0
+  git -C "$path" submodule update --init --recursive >/dev/null 2>&1 || true
+}
+
 copy_files_between() {
   local src="$1"
   local dst="$2"
@@ -400,6 +407,7 @@ open_path() {
     fi
     mkdir -p "$(dirname "$path")"
     git -C "$root" worktree add "$path" "$branch" >/dev/null
+    init_submodules "$root" "$path"
     copy_files_to_worktree "$root" "$path" "$copyignored" "$copyuntracked" "$copymodified" "$copytracked"
     printf '%s\n' "$path"
     return 0
@@ -415,6 +423,7 @@ open_path() {
   fi
   mkdir -p "$(dirname "$path")"
   git -C "$root" worktree add -b "$branch" "$path" "$from" >/dev/null
+  init_submodules "$root" "$path"
   copy_files_to_worktree "$root" "$path" "$copyignored" "$copyuntracked" "$copymodified" "$copytracked"
   printf '%s\n' "$path"
 }


### PR DESCRIPTION
## Summary
- Add `init_submodules` helper that runs `git submodule update --init --recursive` after worktree creation
- Only runs if `.gitmodules` exists in the root repo
- Silently handles failures to avoid blocking worktree creation

## Problem
Git submodules and worktrees have a known compatibility issue. When creating a worktree from a repo with submodules:
1. Git creates a separate `modules/` directory under `.git/worktrees/<name>/modules/`
2. The submodule's `.git` file gets a relative path pointing to this directory
3. But git only creates a partial config file there - missing `HEAD`, `objects`, `refs`, etc.

This leaves the submodule in a broken state where every git command fails.

## Test plan
- [x] All existing tests pass
- [x] Tested manually with a repo containing submodules